### PR TITLE
Fixed the exists check

### DIFF
--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -1,4 +1,4 @@
-if !exists(g:macvim_skim_app_path)
+if !exists("g:macvim_skim_app_path")
     let g:macvim_skim_app_path='/Applications/Skim.app'
 endif
 


### PR DESCRIPTION
You have to surround the variable with quotes
before passing it to exists, otherwise vim will
try and dereference it first.