### PR TITLE
Switched to nnoremap, buffer and localleader

### DIFF
--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -3,10 +3,40 @@ if !exists("g:macvim_skim_app_path")
 endif
 
 " Activate skim
-execute('map ,v :w<CR>:silent !'.g:macvim_skim_app_path.'/Contents/SharedSupport/displayline -r <C-r>=line(".")<CR> %<.pdf %<CR><CR>')
-execute('map ,p :w<CR>:silent !pdflatex -synctex=1 --interaction=nonstopmode %:p <CR>:silent !'.g:macvim_skim_app_path.'/Contents/SharedSupport/displayline -r <C-r>=line(".")<CR> %<.pdf %<CR><CR>')
-execute('map ,m :w<CR>:silent !make <CR>:silent !'.g:macvim_skim_app_path.'/Contents/SharedSupport/displayline -r <C-r>=line(".")<CR> %<.pdf %<CR><CR>')
-" Reactivate VIM
-execute('map ,r :w<CR>:silent !'.g:macvim_skim_app_path.'/Contents/SharedSupport/displayline -r <C-r>=line(".")<CR> %<.pdf %<CR>:silent !osascript -e "tell application \"MacVim\" to activate" <CR><CR>')
-execute('map ,t :w<CR>:silent !pdflatex -synctex=1 --interaction=nonstopmode %:p <CR>:silent !'.g:macvim_skim_app_path.'/Contents/SharedSupport/displayline -r <C-r>=line(".")<CR> %<.pdf %<CR>:silent !osascript -e "tell application \"MacVim\" to activate" <CR><CR>')
+nnoremap <buffer> <localleader>v
+    \ :w<CR>
+    \ :silent !<C-r>=g:macvim_skim_app_path<CR>/Contents/SharedSupport/displayline
+    \ -r <C-r>=line(".")<CR>
+    \ %<.pdf %<CR><CR>
+
+nnoremap <buffer> <localleader>p
+    \ :w<CR>
+    \ :silent !pdflatex -synctex=1 --interaction=nonstopmode %:p <CR>
+    \ :silent !<C-r>=g:macvim_skim_app_path<CR>/Contents/SharedSupport/displayline
+    \ -r <C-r>=line(".")<CR>
+    \ %<.pdf %<CR><CR>
+
+nnoremap <buffer> <localleader>m
+    \ :w<CR>
+    \ !make <CR>
+    \ :silent !<C-r>=g:macvim_skim_app_path<CR>/Contents/SharedSupport/displayline
+    \ -r <C-r>=line(".")<CR>
+    \ %<.pdf %<CR><CR>
+" " Reactivate Vim
+nnoremap <buffer> <localleader>r
+    \ :w<CR>
+    \ :silent !<C-r>=g:macvim_skim_app_path<CR>/Contents/SharedSupport/displayline
+    \ -r <C-r>=line(".")<CR>
+    \ %<.pdf %<CR>
+    \ :silent !osascript -e "tell application \"MacVim\" to activate" <CR><CR>
+
+nnoremap <buffer> <localleader>t
+    \ :w<CR>
+    \ :silent !pdflatex -synctex=1 --interaction=nonstopmode %:p <CR>
+    \ :silent !<C-r>=g:macvim_skim_app_path<CR>/Contents/SharedSupport/displayline
+    \ -r <C-r>=line(".")<CR>
+    \ %<.pdf %<CR>
+    \ :silent !osascript -e "tell application \"MacVim\" to activate" <CR><CR>
+
+
 

--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -1,4 +1,4 @@
-if !exists(g:macvim_skim_app_path)
+if !exists("g:macvim_skim_app_path")
     let g:macvim_skim_app_path='/Applications/Skim.app'
 endif
 


### PR DESCRIPTION
I switched to using nnoremap,
and only defining the commands for the current buffer.

Since ftplugins are only run once you know that the filetype
is tex, go ahead an define the mappings unconditionally,
but use `<buffer>` so that they only get loaded for the current (tex)
buffer, not all open buffers.

Also, this is a filetype specific command, so it makes sense
to use `<localleader>` (which I have mapped to `,` anyways),
so now people who remap local leader are happy too.

Also, I split the commands up by line, that should
make it easier to see what's going on.  It also
highlights some of the redundancy, perhaps there should
be a function defined?

This branch also includes the exists check I fixed earlier, since I couldn't load the plugin at all with that constantly crashing.  Maybe resolve that pull request first.