### PR TITLE
Used `set -x` instead of manually echoing commands

### DIFF
--- a/macvim-skim/macvim-load-line
+++ b/macvim-skim/macvim-load-line
@@ -8,10 +8,14 @@ echo file: $file
 echo line: $line
 echo debug: $debug
 
+if [[ -n "$debug" ]]; then
+    # Echo all the commands
+    set -x
+fi
+
 for server in `mvim --serverlist`
 do
-if [[ $debug ]] ; then echo mvim --servername $server --remote-expr "MVS_Focus('$file', '$line')"; fi
-finished=`mvim --servername $server --remote-expr "MVS_Focus('$file', '$line')"`
+    finished=`mvim --servername $server --remote-expr "MVS_Focus('$file', '$line')"`
     if [[ $finished > 0 ]]
     then
       echo Succeeded on servername: $server


### PR DESCRIPTION
This way, if you change the command, you don't have to change
it again in the debug line, and there is no chance of hilarious
confusion.

Just to clarify, this will produce more output, as it will echo each command.
An example trace:

```
file: essay.tex
line: 200
debug: 1
++ mvim --serverlist
+ for server in '`mvim --serverlist`'
++ mvim --servername GVIM --remote-expr 'MVS_Focus('\''essay.tex'\'', '\''200'\'')'
+ finished=1
+ [[ 1 > 0 ]]
+ echo Succeeded on servername: GVIM
Succeeded on servername: GVIM
+ break
```